### PR TITLE
Fix stubbed url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each scenario uses an AWS CloudFormation template to  deploy your game, creating
 
 ## Prerequisites
 
-* Amazon GameLift plugin for Unreal download package. Download a zip file from [Amazon GameLift Getting Started](https://aws.amazon.com/gamelift/getting-started/). Or clone the plugin from the [Github repo](link to repo)
+* Amazon GameLift plugin for Unreal download package. Download a zip file from [Amazon GameLift Getting Started](https://aws.amazon.com/gamelift/getting-started/). Or clone the plugin from the [Github repo](https://github.com/aws/amazon-gamelift-plugin-unreal)
 * Microsoft Visual Studio 2019 or newer.
 * A source-built version of the Unreal Engine editor. Required to develop server build components for a multiplayer game. See the Unreal Engine documentation: 
     *  [Accessing Unreal Engine source code on GitHub](https://www.unrealengine.com/ue-on-github). Requires  GitHub and Epic Games accounts.


### PR DESCRIPTION
```
* Amazon GameLift plugin for Unreal download package. Download a zip file from [Amazon GameLift Getting Started](https://aws.amazon.com/gamelift/getting-started/). Or clone the plugin from the [Github repo](https://github.com/aws/amazon-gamelift-plugin-unreal)
```