### PR TITLE
Updated for UE5.4

### DIFF
--- a/GameLiftPlugin/Source/AWSSDK/Include/aws/cloudformation/model/AccountFilterType.h
+++ b/GameLiftPlugin/Source/AWSSDK/Include/aws/cloudformation/model/AccountFilterType.h
@@ -18,7 +18,7 @@ namespace Model
     NOT_SET,
     NONE,
     INTERSECTION,
-    DIFFERENCE,
+    _DIFFERENCE,
     UNION
   };
 

--- a/GameLiftPlugin/Source/GameLiftCore/Private/AWSConfigFileProfile.cpp
+++ b/GameLiftPlugin/Source/GameLiftCore/Private/AWSConfigFileProfile.cpp
@@ -3,6 +3,7 @@
 
 #include "AWSConfigFileProfile.h"
 
+#include "GameLiftCoreLog.h"
 #include "Utils/StringConvertors.h"
 
 #define LOCTEXT_NAMESPACE "AWSConfigFileProfile"

--- a/GameLiftPlugin/Source/GameLiftCore/Private/AWSScenariosDeployer.h
+++ b/GameLiftPlugin/Source/GameLiftCore/Private/AWSScenariosDeployer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "IAWSScenariosDeployer.h"
+#include "aws/gamelift/core/errors.h"
 #include "AwsScenarios/IAWSScenario.h"
 
 class AWSScenariosDeployer : public IAWSScenariosDeployer

--- a/GameLiftPlugin/Source/GameLiftCore/Private/AwsScenarios/IAwsScenario.h
+++ b/GameLiftPlugin/Source/GameLiftCore/Private/AwsScenarios/IAwsScenario.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "IAWSAccountInstance.h"
+#include "aws/gamelift/core/enums.h"
 
 namespace AwsScenarios
 {

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/SMenu/SConnectAnywhereFleetMenu.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/SMenu/SConnectAnywhereFleetMenu.h
@@ -4,11 +4,13 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "IGameLiftAnywhereHandler.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
 #include "Widgets/SCompoundWidget.h"
 
 #include "Types/FTextIntPair.h"
 
+class SNamedRow;
 class SBootstrapStatus;
 class SEditableTextBox;
 class SErrorBanner;

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/SMenu/SGameLiftDeployManagedEC2Menu.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/SMenu/SGameLiftDeployManagedEC2Menu.h
@@ -7,6 +7,7 @@
 #include "Widgets/DeclarativeSyntaxSupport.h"
 #include "Widgets/SCompoundWidget.h"
 
+struct FTextIntPair;
 class SWindow;
 class SPathInput;
 

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/SWidgets/SDeploymentFields.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/SWidgets/SDeploymentFields.h
@@ -73,12 +73,12 @@ private:
 	TSharedPtr<SPathInput> OutConfigFilePathInput;
 };
 
-TSharedRef<SDeploymentFields> AsSDeploymentFieldsRef(TSharedPtr<SWidget> WidgetToCast)
+inline TSharedRef<SDeploymentFields> AsSDeploymentFieldsRef(TSharedPtr<SWidget> WidgetToCast)
 {
 	return StaticCastSharedRef<SDeploymentFields>(WidgetToCast.ToSharedRef());
 }
 
-TSharedRef<SDeploymentFields> AsSDeploymentFieldsRef(TSharedRef<SWidget> WidgetToCast)
+inline TSharedRef<SDeploymentFields> AsSDeploymentFieldsRef(TSharedRef<SWidget> WidgetToCast)
 {
 	return StaticCastSharedRef<SDeploymentFields>(WidgetToCast);
 }

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/SWidgets/SDeploymentStatus.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/SWidgets/SDeploymentStatus.h
@@ -52,12 +52,12 @@ private:
 	TSharedPtr<SWidget> LoadingWidget;
 };
 
-TSharedRef<SDeploymentStatus> AsSDeploymentStatusRef(TSharedPtr<SWidget> WidgetToCast)
+inline TSharedRef<SDeploymentStatus> AsSDeploymentStatusRef(TSharedPtr<SWidget> WidgetToCast)
 {
 	return StaticCastSharedRef<SDeploymentStatus>(WidgetToCast.ToSharedRef());
 }
 
-TSharedRef<SDeploymentStatus> AsSDeploymentStatusRef(TSharedRef<SWidget> WidgetToCast)
+inline TSharedRef<SDeploymentStatus> AsSDeploymentStatusRef(TSharedRef<SWidget> WidgetToCast)
 {
 	return StaticCastSharedRef<SDeploymentStatus>(WidgetToCast);
 }

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EBootstrapMessageState.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EBootstrapMessageState.h
@@ -22,7 +22,7 @@ constexpr auto EBootstrapMessageStateFromInt(int State)
 	return EBootstrapMessageState(State);
 }
 
-FText EBootstrapMessageStateToString(EBootstrapMessageState State)
+inline FText EBootstrapMessageStateToString(EBootstrapMessageState State)
 {
 	switch (State)
 	{

--- a/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EFleetOperatingSystem.h
+++ b/GameLiftPlugin/Source/GameLiftPlugin/Private/Types/EFleetOperatingSystem.h
@@ -12,7 +12,7 @@ enum class EFleetOperatingSystem : int
 	AmazonLinux2023
 };
 
-TArray<EFleetOperatingSystem> MakeSupportedOperatingSystemList()
+inline TArray<EFleetOperatingSystem> MakeSupportedOperatingSystemList()
 {
 	TArray<EFleetOperatingSystem> OSList;
 	OSList.Add(EFleetOperatingSystem::Windows2016);
@@ -21,7 +21,7 @@ TArray<EFleetOperatingSystem> MakeSupportedOperatingSystemList()
 	return OSList;
 }
 
-FText EFleetOperatingSystemToName(EFleetOperatingSystem OSType)
+inline FText EFleetOperatingSystemToName(EFleetOperatingSystem OSType)
 {
 	switch (OSType)
 	{
@@ -36,7 +36,7 @@ FText EFleetOperatingSystemToName(EFleetOperatingSystem OSType)
 	}
 }
 
-FText EFleetOperatingSystemToValue(EFleetOperatingSystem OSType)
+inline FText EFleetOperatingSystemToValue(EFleetOperatingSystem OSType)
 {
 	switch (OSType)
 	{
@@ -51,7 +51,7 @@ FText EFleetOperatingSystemToValue(EFleetOperatingSystem OSType)
 	}
 }
 
-EFleetOperatingSystem EFleetOperatingSystemFromValueText(const FText& OSValue)
+inline EFleetOperatingSystem EFleetOperatingSystemFromValueText(const FText& OSValue)
 {
 	if (OSValue.EqualTo(Menu::DeployManagedEC2::kWindowsServer2016Value))
 	{


### PR DESCRIPTION
*Issue #: 44

*Description of changes:*

Updates to fix the build in UE 5.4. Mainly added imports and inline to a few methods that were causing linker errors. I'm not sure why the AccountFilterType change is necessary but it was the only way I could get it to build. My guess is DIFFERENCE conflicts with an engine enum or something. If anyone knows how to avoid changing the enum value name let me know and I'll update it
